### PR TITLE
update cjose to 0.6.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #! groovy
 @Library('gcs-build-scripts') _
 
-def CJOSE_PACKAGE_VERSION="0.5.1"
-def CJOSE_SOURCE_TARBALL_NAME = "${CJOSE_PACKAGE_VERSION}.tar.gz"
-def CJOSE_SOURCE_TARBALL_URL = "https://github.com/cisco/cjose/archive/${CJOSE_SOURCE_TARBALL_NAME}"
+def CJOSE_PACKAGE_VERSION="0.6.2"
+def CJOSE_SOURCE_TARBALL_NAME = "cjose-${CJOSE_PACKAGE_VERSION}.tar.gz"
+def CJOSE_SOURCE_TARBALL_URL = "https://github.com/zmartzone/cjose/releases/download/v${CJOSE_PACKAGE_VERSION}/${CJOSE_SOURCE_TARBALL_NAME}"
 def CJOSE_EXCLUDE = []
 
 def JQ_PACKAGE_VERSION="1.5"

--- a/packaging/fedora/cjose.spec
+++ b/packaging/fedora/cjose.spec
@@ -1,11 +1,11 @@
 Name:           cjose
-Version:        0.5.1
+Version:        0.6.2
 Release:        1%{?dist}
 Summary:        C library implementing the Javascript Object Signing and Encryption (JOSE)
 Group:          System Environment/Libraries
 License:        MIT
-URL:            https://github.com/cisco/cjose
-Source0:        https://github.com/cisco/cjose/archive/%{version}.tar.gz
+URL:            https://github.com/zmartzone/cjose
+Source0:        https://github.com/zmartzone/cjose/releases/download/v%{version}/cjose-%{version}.tar.gz
 Vendor:         %{VENDOR}
 Epoch:          1
 


### PR DESCRIPTION
This points to a fork of cjose that is maintained by mod_auth_openidc devs.

[[sc-17786]](https://app.shortcut.com/globus/story/17786/update-cjose-to-upstream-version)